### PR TITLE
Add HTML page with two audio players

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>Audio Spieler</title>
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      font-family: sans-serif;
+    }
+    .player {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin: 1em 0;
+    }
+  </style>
+</head>
+<body>
+  <h1>Audio Player Beispiel</h1>
+
+  <div class="player">
+    <h2>Stimme</h2>
+    <audio id="voicePlayer" controls src="stimme.mp3">
+      Ihr Browser unterstützt das Audio-Element nicht.
+    </audio>
+    <input id="voiceUpload" type="file" accept="audio/mpeg">
+  </div>
+
+  <div class="player">
+    <h2>Beat</h2>
+    <audio id="beatPlayer" controls src="beat.mp3">
+      Ihr Browser unterstützt das Audio-Element nicht.
+    </audio>
+    <input id="beatUpload" type="file" accept="audio/mpeg">
+  </div>
+
+  <script>
+    const voiceUpload = document.getElementById('voiceUpload');
+    const voicePlayer = document.getElementById('voicePlayer');
+    voiceUpload.addEventListener('change', function () {
+      const file = this.files[0];
+      if (file) {
+        voicePlayer.src = URL.createObjectURL(file);
+      }
+    });
+
+    const beatUpload = document.getElementById('beatUpload');
+    const beatPlayer = document.getElementById('beatPlayer');
+    beatUpload.addEventListener('change', function () {
+      const file = this.files[0];
+      if (file) {
+        beatPlayer.src = URL.createObjectURL(file);
+      }
+    });
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add `index.html` with audio elements for voice and beat
- center audio players and allow uploading custom mp3 files

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68932b37d0b083209238c46ce08e120f